### PR TITLE
Update ParticleFilters compat to include v0.5.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ Gtk = "1.1"
 POMDPTools = "1.0"
 POMDPs = "1.0"
 Parameters = "0.12"
-ParticleFilters = "0.6"
+ParticleFilters = "0.5.7, 0.6"
 StaticArrays = "1.6"
 
 [extras]


### PR DESCRIPTION
- Added ParticleFilters v0.5.7 to the compatibility bounds
- Resolves dependency conflicts in the POMDPs.jl ecosystem

## Tests
  - [x] Run package tests with `julia --project=. -e 'using Pkg; Pkg.test()'`
  - [x] Verify dependency resolution with `Pkg.resolve()` and `Pkg.instantiate()`
  - [x] All tests pass successfully